### PR TITLE
Menu active items

### DIFF
--- a/models/core/prototypes/DefaultController.php
+++ b/models/core/prototypes/DefaultController.php
@@ -3,7 +3,6 @@ declare(strict_types = 1);
 
 namespace app\models\core\prototypes;
 
-use app\models\sys\users\Users;
 use pozitronik\core\helpers\ControllerHelper;
 use pozitronik\core\traits\ControllerTrait;
 use pozitronik\sys_exceptions\models\LoggedException;

--- a/widgets/smartadmin/menu/MenuWidget.php
+++ b/widgets/smartadmin/menu/MenuWidget.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace app\widgets\smartadmin\menu;
 
+use Yii;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use yii\widgets\Menu as YiiMenuWidget;
@@ -14,6 +15,8 @@ use yii\widgets\Menu as YiiMenuWidget;
  * Виджет для отрисовки меню
  */
 class MenuWidget extends YiiMenuWidget {
+	private bool $_activeItemFound = false;
+
 	/**
 	 * @inheritdoc
 	 */
@@ -21,6 +24,26 @@ class MenuWidget extends YiiMenuWidget {
 		parent::init();
 
 		$this->linkTemplate = '<a href="{url}" data-filter-tags="{tags}">{icon}<span class="nav-link-text">{label}</span></a>';
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	protected function isItemActive($item): bool {
+		//если нашли активный элемент меню, к чему дальнейшие поиски?!
+		if ($this->_activeItemFound) {
+			return false;
+		}
+
+		if (Yii::$app->controller && null !== ($route = ArrayHelper::getValue($item, 'url.0'))) {
+			//дополнительная проверка в связи с возможностью передачи Url без указания экшона (по-умолчанию)
+			$syntheticRoute = trim(Yii::getAlias($route), '/').'/'.Yii::$app->controller->defaultAction;
+			if ($syntheticRoute === Yii::$app->controller->route) {
+				$item['url'][0] = '/'.$syntheticRoute;
+			}
+		}
+
+		return $this->_activeItemFound = parent::isItemActive($item);
 	}
 
 	/**

--- a/widgets/smartadmin/menu/MenuWidget.php
+++ b/widgets/smartadmin/menu/MenuWidget.php
@@ -35,7 +35,7 @@ class MenuWidget extends YiiMenuWidget {
 			return false;
 		}
 
-		if (Yii::$app->controller && null !== ($route = ArrayHelper::getValue($item, 'url.0'))) {
+		if (Yii::$app->controller && (null !== $route = ArrayHelper::getValue($item, 'url.0'))) {
 			//дополнительная проверка в связи с возможностью передачи Url без указания экшона (по-умолчанию)
 			$syntheticRoute = trim(Yii::getAlias($route), '/').'/'.Yii::$app->controller->defaultAction;
 			if ($syntheticRoute === Yii::$app->controller->route) {


### PR DESCRIPTION
1. Скорректирована проверка статуса активного элемента меню на случай, если не указать экшон
2. Ограничил перебор элементов меню на проверку статуса активности, если активный элемент уже был найден